### PR TITLE
Suppress sets module is deprecated warning.

### DIFF
--- a/plugin/python_calltips.vim
+++ b/plugin/python_calltips.vim
@@ -141,6 +141,8 @@ python << PYTHONEOF
 import vim
 import __builtin__
 from string import letters
+import warnings
+warnings.filterwarnings("ignore", "the sets module is deprecated")
 try:
     from sets import Set
 except:


### PR DESCRIPTION
On some combinations of vim / python a deprecation warning is displayed. Interrupting file open and very annoying. This fix suppresses that deprecation warning.
